### PR TITLE
Add latent space visualization and GPU fix

### DIFF
--- a/feature_extraction.py
+++ b/feature_extraction.py
@@ -88,6 +88,7 @@ def extract_features(encoder, raster_path, patch_size=256, stride=128, batch_siz
                         batch_tensor = torch.from_numpy(batch_array).float()
                         if batch_tensor.ndim == 4:
                             batch_tensor = batch_tensor.permute(0, 3, 1, 2)
+                        batch_tensor = batch_tensor.to(device)
 
                         with torch.no_grad():
                             batch_features = encoder(batch_tensor).cpu().numpy()
@@ -107,6 +108,7 @@ def extract_features(encoder, raster_path, patch_size=256, stride=128, batch_siz
                 batch_tensor = torch.from_numpy(batch_array).float()
                 if batch_tensor.ndim == 4:
                     batch_tensor = batch_tensor.permute(0, 3, 1, 2)
+                batch_tensor = batch_tensor.to(device)
 
                 with torch.no_grad():
                     batch_features = encoder(batch_tensor).cpu().numpy()

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from data_preparation import create_contrastive_pairs, load_contrastive_pairs
 from model import train_siamese_model, load_models
 from feature_extraction import extract_features, detect_anomalies
 from evaluation import evaluate_results, visualize_results, create_results_report
+from visualization import plot_latent_space
 
 def setup_args():
     """Parse command line arguments"""
@@ -79,10 +80,10 @@ def main():
         
         # Sample random patches
         print(f"Sampling {args.n_samples} random patches from {len(raster_paths)} raster files...")
-        patches, patch_locations, _ = sample_random_patches(
-            raster_paths, 
-            patch_size=args.patch_size, 
-            n_samples=args.n_samples, 
+        patches, patch_locations, patch_sources = sample_random_patches(
+            raster_paths,
+            patch_size=args.patch_size,
+            n_samples=args.n_samples,
             save_dir=patch_dir
         )
         
@@ -102,6 +103,16 @@ def main():
             X1, X2, labels,
             epochs=args.epochs,
             save_dir=model_dir
+        )
+
+        # Visualize latent space without and with patch source labels
+        plot_latent_space(encoder, patches, output_dir=results_dir)
+        plot_latent_space(
+            encoder,
+            patches,
+            patch_sources=patch_sources,
+            output_dir=results_dir,
+            prefix="latent_space_features",
         )
     else:
         # Load pre-trained models

--- a/visualization.py
+++ b/visualization.py
@@ -1,0 +1,69 @@
+import os
+import numpy as np
+import torch
+import matplotlib.pyplot as plt
+from sklearn.decomposition import PCA
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
+
+
+def _prepare_batch(patches):
+    batch = patches.astype(np.float32)
+    if batch.ndim == 3:  # N,H,W
+        batch = np.expand_dims(batch, 1)
+    elif batch.ndim == 4 and batch.shape[-1] in {1, 3}:  # N,H,W,C -> N,C,H,W
+        batch = np.transpose(batch, (0, 3, 1, 2))
+    return torch.from_numpy(batch)
+
+
+def plot_latent_space(encoder, patches, patch_sources=None, output_dir="results", prefix="latent_space"):
+    """Plot 2D and 3D PCA projections of encoder embeddings."""
+    device = torch.device("cpu")
+    if isinstance(encoder, torch.nn.Module):
+        device = next(encoder.parameters()).device
+        encoder.eval()
+
+    # Compute embeddings in batches to avoid memory issues
+    features = []
+    batch_size = 64
+    for start in range(0, len(patches), batch_size):
+        batch = _prepare_batch(patches[start:start + batch_size])
+        batch = batch.to(device)
+        with torch.no_grad():
+            emb = encoder(batch).cpu().numpy()
+        features.append(emb)
+    features = np.concatenate(features, axis=0)
+
+    # 2D PCA
+    pca2 = PCA(n_components=2)
+    reduced2 = pca2.fit_transform(features)
+    plt.figure(figsize=(8, 6))
+    if patch_sources is not None:
+        unique_sources = sorted(set(patch_sources))
+        for src in unique_sources:
+            idx = [i for i, s in enumerate(patch_sources) if s == src]
+            plt.scatter(reduced2[idx, 0], reduced2[idx, 1], s=5, alpha=0.6, label=src)
+        plt.legend(fontsize="small")
+    else:
+        plt.scatter(reduced2[:, 0], reduced2[:, 1], s=5, alpha=0.6)
+    plt.title("Latent Space (2D PCA)")
+    os.makedirs(output_dir, exist_ok=True)
+    plt.savefig(os.path.join(output_dir, f"{prefix}_2d.png"))
+    plt.close()
+
+    # 3D PCA
+    pca3 = PCA(n_components=3)
+    reduced3 = pca3.fit_transform(features)
+    fig = plt.figure(figsize=(8, 6))
+    ax = fig.add_subplot(111, projection="3d")
+    if patch_sources is not None:
+        for src in unique_sources:
+            idx = [i for i, s in enumerate(patch_sources) if s == src]
+            ax.scatter(reduced3[idx, 0], reduced3[idx, 1], reduced3[idx, 2], s=5, alpha=0.6, label=src)
+        ax.legend(fontsize="small")
+    else:
+        ax.scatter(reduced3[:, 0], reduced3[:, 1], reduced3[:, 2], s=5, alpha=0.6)
+    ax.set_title("Latent Space (3D PCA)")
+    plt.savefig(os.path.join(output_dir, f"{prefix}_3d.png"))
+    plt.close()
+
+    return features


### PR DESCRIPTION
## Summary
- add helper to plot 2D/3D latent space of encoder embeddings
- visualize latent space after training
- ensure feature extraction tensors are moved to same device as encoder

## Testing
- `python -m py_compile visualization.py feature_extraction.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_684f34f0fd688321b0d6e03b36f65a5a