### PR TITLE
Add PCA overlay plotting for site patches

### DIFF
--- a/latent_plot.py
+++ b/latent_plot.py
@@ -1,0 +1,78 @@
+import os
+import argparse
+import numpy as np
+
+from data_loader import (
+    load_shapefiles,
+    load_site_locations,
+    get_raster_paths,
+    sample_random_patches,
+    sample_site_patches,
+)
+from model import load_models
+from visualization import compute_embeddings, plot_latent_overlay
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Plot encoder latent space with known sites")
+    parser.add_argument(
+        "--data_path",
+        type=str,
+        default="/project/joycelab-niall/ruin_repo",
+        help="Path to data directory",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default="latent_results",
+        help="Directory to save latent space plots",
+    )
+    parser.add_argument("--raster_limit", type=int, default=3, help="Number of rasters to sample")
+    parser.add_argument("--patch_size", type=int, default=256, help="Size of patches")
+    parser.add_argument("--n_samples", type=int, default=5000, help="Number of random patches")
+    parser.add_argument(
+        "--model_dir", type=str, default="models", help="Directory containing trained models"
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    # Load data
+    shapefiles = load_shapefiles(args.data_path)
+    known_sites = load_site_locations(args.data_path)
+    if not hasattr(known_sites, "geometry"):
+        known_sites = shapefiles["sites"]
+
+    raster_paths = get_raster_paths(args.data_path, limit=args.raster_limit)
+
+    # Sample patches
+    patches, _, _ = sample_random_patches(
+        raster_paths, patch_size=args.patch_size, n_samples=args.n_samples
+    )
+    site_patches, _, _ = sample_site_patches(raster_paths, known_sites, patch_size=args.patch_size)
+
+    # Load encoder
+    encoder, _ = load_models(save_dir=args.model_dir)
+
+    # Compute embeddings
+    patch_emb = compute_embeddings(encoder, patches)
+    site_emb = (
+        compute_embeddings(encoder, site_patches)
+        if len(site_patches) > 0
+        else np.empty((0, patch_emb.shape[1]))
+    )
+
+    # Plot latent space overlay
+    plot_latent_overlay(
+        patch_emb,
+        site_emb,
+        output_dir=args.output_dir,
+        prefix="latent_with_sites",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/visualization.py
+++ b/visualization.py
@@ -89,3 +89,45 @@ def plot_latent_space(encoder, patches, patch_sources=None, output_dir="results"
     plt.close()
 
     return features
+
+
+def plot_latent_overlay(base_features, overlay_features, output_dir="results", prefix="latent_overlay", labels=("random", "site")):
+    """Plot PCA projections with overlays.
+
+    PCA is fit on ``base_features`` and applied to ``overlay_features`` so that
+    the orientation of the latent space is determined solely by the random
+    samples. Overlay points are then plotted on top using a different marker.
+    """
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    # 2D PCA
+    pca2 = PCA(n_components=2)
+    base_2d = pca2.fit_transform(base_features)
+    overlay_2d = pca2.transform(overlay_features) if len(overlay_features) > 0 else np.empty((0, 2))
+
+    plt.figure(figsize=(8, 6))
+    plt.scatter(base_2d[:, 0], base_2d[:, 1], s=5, alpha=0.6, color="gray", label=labels[0])
+    if len(overlay_2d) > 0:
+        plt.scatter(overlay_2d[:, 0], overlay_2d[:, 1], s=20, color="red", marker="x", label=labels[1])
+    plt.legend(fontsize="small")
+    plt.title("Latent Space (2D PCA)")
+    plt.savefig(os.path.join(output_dir, f"{prefix}_2d.png"))
+    plt.close()
+
+    # 3D PCA
+    pca3 = PCA(n_components=3)
+    base_3d = pca3.fit_transform(base_features)
+    overlay_3d = pca3.transform(overlay_features) if len(overlay_features) > 0 else np.empty((0, 3))
+
+    fig = plt.figure(figsize=(8, 6))
+    ax = fig.add_subplot(111, projection="3d")
+    ax.scatter(base_3d[:, 0], base_3d[:, 1], base_3d[:, 2], s=5, alpha=0.6, color="gray", label=labels[0])
+    if len(overlay_3d) > 0:
+        ax.scatter(overlay_3d[:, 0], overlay_3d[:, 1], overlay_3d[:, 2], s=20, color="red", marker="x", label=labels[1])
+    ax.legend(fontsize="small")
+    ax.set_title("Latent Space (3D PCA)")
+    plt.savefig(os.path.join(output_dir, f"{prefix}_3d.png"))
+    plt.close()
+
+    return base_2d, overlay_2d


### PR DESCRIPTION
## Summary
- update `latent_plot.py` to overlay site embeddings on random patch embeddings
- add `plot_latent_overlay` helper in `visualization.py`

## Testing
- `python -m py_compile latent_plot.py visualization.py`


------
https://chatgpt.com/codex/tasks/task_e_684f6f7c14dc83218908095a75e4d1ce