### PR TITLE
Add patch source coloring to overlay plots

### DIFF
--- a/latent_plot.py
+++ b/latent_plot.py
@@ -1,0 +1,82 @@
+import os
+import argparse
+import numpy as np
+
+from data_loader import (
+    load_shapefiles,
+    load_site_locations,
+    get_raster_paths,
+    sample_random_patches,
+    sample_site_patches,
+)
+from model import load_models
+from visualization import compute_embeddings, plot_latent_overlay
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Plot encoder latent space with known sites")
+    parser.add_argument(
+        "--data_path",
+        type=str,
+        default="/project/joycelab-niall/ruin_repo",
+        help="Path to data directory",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default="latent_results",
+        help="Directory to save latent space plots",
+    )
+    parser.add_argument("--raster_limit", type=int, default=3, help="Number of rasters to sample")
+    parser.add_argument("--patch_size", type=int, default=256, help="Size of patches")
+    parser.add_argument("--n_samples", type=int, default=5000, help="Number of random patches")
+    parser.add_argument(
+        "--model_dir", type=str, default="models", help="Directory containing trained models"
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    # Load data
+    shapefiles = load_shapefiles(args.data_path)
+    known_sites = load_site_locations(args.data_path)
+    if not hasattr(known_sites, "geometry"):
+        known_sites = shapefiles["sites"]
+
+    raster_paths = get_raster_paths(args.data_path, limit=args.raster_limit)
+
+    # Sample patches
+    patches, _, patch_sources = sample_random_patches(
+        raster_paths, patch_size=args.patch_size, n_samples=args.n_samples
+    )
+    site_patches, _, site_sources = sample_site_patches(
+        raster_paths, known_sites, patch_size=args.patch_size
+    )
+
+    # Load encoder
+    encoder, _ = load_models(save_dir=args.model_dir)
+
+    # Compute embeddings
+    patch_emb = compute_embeddings(encoder, patches)
+    site_emb = (
+        compute_embeddings(encoder, site_patches)
+        if len(site_patches) > 0
+        else np.empty((0, patch_emb.shape[1]))
+    )
+
+    # Plot latent space overlay
+    plot_latent_overlay(
+        patch_emb,
+        site_emb,
+        base_sources=patch_sources,
+        overlay_sources=["known_site"] * len(site_emb),
+        output_dir=args.output_dir,
+        prefix="latent_with_sites",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -10,7 +10,12 @@ from data_preparation import create_contrastive_pairs, load_contrastive_pairs
 from model import train_siamese_model, load_models
 from feature_extraction import extract_features, detect_anomalies
 from evaluation import evaluate_results, visualize_results, create_results_report
-from visualization import plot_latent_space, plot_training_loss, compute_embeddings
+from visualization import (
+    plot_latent_space,
+    plot_training_loss,
+    compute_embeddings,
+    plot_latent_overlay,
+)
 
 
 def setup_args():
@@ -185,20 +190,13 @@ def main():
             if len(site_patches_det) > 0
             else np.empty((0, features.shape[1]))
         )
-        all_features_det = (
-            np.concatenate([features, site_features_det])
-            if len(site_features_det) > 0
-            else features
-        )
-        all_labels_det = ["raster"] * len(features) + ["known_site"] * len(site_features_det)
-
-        plot_latent_space(
-            encoder,
-            all_features_det,
-            patch_sources=all_labels_det,
+        plot_latent_overlay(
+            features,
+            site_features_det,
+            base_sources=[os.path.basename(test_raster)] * len(features),
+            overlay_sources=["known_site"] * len(site_features_det),
             output_dir=results_dir,
             prefix="detection_latent_space",
-            precomputed=True,
         )
         
         # Detect anomalies

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ scikit-learn==1.2.2
 pandas==1.5.3
 shapely==2.0.1
 tqdm==4.65.0
+umap-learn==0.5.7

--- a/visualization.py
+++ b/visualization.py
@@ -3,6 +3,8 @@ import numpy as np
 import torch
 import matplotlib.pyplot as plt
 from sklearn.decomposition import PCA
+from sklearn.manifold import TSNE
+import umap
 from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
 
 
@@ -89,3 +91,203 @@ def plot_latent_space(encoder, patches, patch_sources=None, output_dir="results"
     plt.close()
 
     return features
+
+
+def plot_latent_overlay(
+    base_features,
+    overlay_features,
+    base_sources=None,
+    overlay_sources=None,
+    output_dir="results",
+    prefix="latent_overlay",
+):
+    """Plot PCA, t-SNE and UMAP projections with overlays.
+
+    ``base_sources`` and ``overlay_sources`` allow coloring points by their
+    originating raster, similar to :func:`plot_latent_space`. PCA and UMAP are
+    fit only on ``base_features`` so the random patches determine the orienta-
+    tion. t-SNE does not support transforming new samples, so both feature sets
+    are concatenated before fitting.
+    """
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    base_sources = base_sources or ["base"] * len(base_features)
+    overlay_sources = overlay_sources or ["overlay"] * len(overlay_features)
+    all_sources = base_sources + overlay_sources
+    unique_sources = sorted(set(all_sources))
+    cmap = plt.get_cmap("tab10", len(unique_sources))
+    color_map = {src: cmap(i) for i, src in enumerate(unique_sources)}
+
+    # ----- PCA -----
+    pca2 = PCA(n_components=2)
+    base_pca2 = pca2.fit_transform(base_features)
+    overlay_pca2 = pca2.transform(overlay_features) if len(overlay_features) > 0 else np.empty((0, 2))
+
+    plt.figure(figsize=(8, 6))
+    for src in unique_sources:
+        base_idx = [i for i, s in enumerate(base_sources) if s == src]
+        over_idx = [i for i, s in enumerate(overlay_sources) if s == src]
+        if base_idx:
+            plt.scatter(base_pca2[base_idx, 0], base_pca2[base_idx, 1], s=5, alpha=0.6, color=color_map[src], label=src)
+        if over_idx:
+            plt.scatter(overlay_pca2[over_idx, 0], overlay_pca2[over_idx, 1], s=20, marker="x", color=color_map[src], label=f"{src}_overlay")
+    handles, labels = plt.gca().get_legend_handles_labels()
+    by_label = dict(zip(labels, handles))
+    plt.legend(by_label.values(), by_label.keys(), fontsize="small")
+    plt.title("Latent Space (2D PCA)")
+    plt.savefig(os.path.join(output_dir, f"{prefix}_pca_2d.png"))
+    plt.close()
+
+    pca3 = PCA(n_components=3)
+    base_pca3 = pca3.fit_transform(base_features)
+    overlay_pca3 = pca3.transform(overlay_features) if len(overlay_features) > 0 else np.empty((0, 3))
+
+    fig = plt.figure(figsize=(8, 6))
+    ax = fig.add_subplot(111, projection="3d")
+    for src in unique_sources:
+        base_idx = [i for i, s in enumerate(base_sources) if s == src]
+        over_idx = [i for i, s in enumerate(overlay_sources) if s == src]
+        if base_idx:
+            ax.scatter(
+                base_pca3[base_idx, 0],
+                base_pca3[base_idx, 1],
+                base_pca3[base_idx, 2],
+                s=5,
+                alpha=0.6,
+                color=color_map[src],
+                label=src,
+            )
+        if over_idx:
+            ax.scatter(
+                overlay_pca3[over_idx, 0],
+                overlay_pca3[over_idx, 1],
+                overlay_pca3[over_idx, 2],
+                s=20,
+                marker="x",
+                color=color_map[src],
+                label=f"{src}_overlay",
+            )
+    handles, labels = ax.get_legend_handles_labels()
+    by_label = dict(zip(labels, handles))
+    ax.legend(by_label.values(), by_label.keys(), fontsize="small")
+    ax.set_title("Latent Space (3D PCA)")
+    plt.savefig(os.path.join(output_dir, f"{prefix}_pca_3d.png"))
+    plt.close()
+
+    # ----- t-SNE -----
+    combined = base_features if len(overlay_features) == 0 else np.vstack([base_features, overlay_features])
+    tsne2 = TSNE(n_components=2, init="pca", random_state=42)
+    combined_2d = tsne2.fit_transform(combined)
+    base_tsne2 = combined_2d[: len(base_features)]
+    overlay_tsne2 = combined_2d[len(base_features) :]
+
+    plt.figure(figsize=(8, 6))
+    for src in unique_sources:
+        base_idx = [i for i, s in enumerate(base_sources) if s == src]
+        over_idx = [i for i, s in enumerate(overlay_sources) if s == src]
+        if base_idx:
+            plt.scatter(base_tsne2[base_idx, 0], base_tsne2[base_idx, 1], s=5, alpha=0.6, color=color_map[src], label=src)
+        if over_idx:
+            plt.scatter(overlay_tsne2[over_idx, 0], overlay_tsne2[over_idx, 1], s=20, marker="x", color=color_map[src], label=f"{src}_overlay")
+    handles, labels = plt.gca().get_legend_handles_labels()
+    by_label = dict(zip(labels, handles))
+    plt.legend(by_label.values(), by_label.keys(), fontsize="small")
+    plt.title("Latent Space (2D t-SNE)")
+    plt.savefig(os.path.join(output_dir, f"{prefix}_tsne_2d.png"))
+    plt.close()
+
+    tsne3 = TSNE(n_components=3, init="pca", random_state=42)
+    combined_3d = tsne3.fit_transform(combined)
+    base_tsne3 = combined_3d[: len(base_features)]
+    overlay_tsne3 = combined_3d[len(base_features) :]
+
+    fig = plt.figure(figsize=(8, 6))
+    ax = fig.add_subplot(111, projection="3d")
+    for src in unique_sources:
+        base_idx = [i for i, s in enumerate(base_sources) if s == src]
+        over_idx = [i for i, s in enumerate(overlay_sources) if s == src]
+        if base_idx:
+            ax.scatter(
+                base_tsne3[base_idx, 0],
+                base_tsne3[base_idx, 1],
+                base_tsne3[base_idx, 2],
+                s=5,
+                alpha=0.6,
+                color=color_map[src],
+                label=src,
+            )
+        if over_idx:
+            ax.scatter(
+                overlay_tsne3[over_idx, 0],
+                overlay_tsne3[over_idx, 1],
+                overlay_tsne3[over_idx, 2],
+                s=20,
+                marker="x",
+                color=color_map[src],
+                label=f"{src}_overlay",
+            )
+    handles, labels = ax.get_legend_handles_labels()
+    by_label = dict(zip(labels, handles))
+    ax.legend(by_label.values(), by_label.keys(), fontsize="small")
+    ax.set_title("Latent Space (3D t-SNE)")
+    plt.savefig(os.path.join(output_dir, f"{prefix}_tsne_3d.png"))
+    plt.close()
+
+    # ----- UMAP -----
+    umap2 = umap.UMAP(n_components=2, random_state=42)
+    base_umap2 = umap2.fit_transform(base_features)
+    overlay_umap2 = umap2.transform(overlay_features) if len(overlay_features) > 0 else np.empty((0, 2))
+
+    plt.figure(figsize=(8, 6))
+    for src in unique_sources:
+        base_idx = [i for i, s in enumerate(base_sources) if s == src]
+        over_idx = [i for i, s in enumerate(overlay_sources) if s == src]
+        if base_idx:
+            plt.scatter(base_umap2[base_idx, 0], base_umap2[base_idx, 1], s=5, alpha=0.6, color=color_map[src], label=src)
+        if over_idx:
+            plt.scatter(overlay_umap2[over_idx, 0], overlay_umap2[over_idx, 1], s=20, marker="x", color=color_map[src], label=f"{src}_overlay")
+    handles, labels = plt.gca().get_legend_handles_labels()
+    by_label = dict(zip(labels, handles))
+    plt.legend(by_label.values(), by_label.keys(), fontsize="small")
+    plt.title("Latent Space (2D UMAP)")
+    plt.savefig(os.path.join(output_dir, f"{prefix}_umap_2d.png"))
+    plt.close()
+
+    umap3 = umap.UMAP(n_components=3, random_state=42)
+    base_umap3 = umap3.fit_transform(base_features)
+    overlay_umap3 = umap3.transform(overlay_features) if len(overlay_features) > 0 else np.empty((0, 3))
+
+    fig = plt.figure(figsize=(8, 6))
+    ax = fig.add_subplot(111, projection="3d")
+    for src in unique_sources:
+        base_idx = [i for i, s in enumerate(base_sources) if s == src]
+        over_idx = [i for i, s in enumerate(overlay_sources) if s == src]
+        if base_idx:
+            ax.scatter(
+                base_umap3[base_idx, 0],
+                base_umap3[base_idx, 1],
+                base_umap3[base_idx, 2],
+                s=5,
+                alpha=0.6,
+                color=color_map[src],
+                label=src,
+            )
+        if over_idx:
+            ax.scatter(
+                overlay_umap3[over_idx, 0],
+                overlay_umap3[over_idx, 1],
+                overlay_umap3[over_idx, 2],
+                s=20,
+                marker="x",
+                color=color_map[src],
+                label=f"{src}_overlay",
+            )
+    handles, labels = ax.get_legend_handles_labels()
+    by_label = dict(zip(labels, handles))
+    ax.legend(by_label.values(), by_label.keys(), fontsize="small")
+    ax.set_title("Latent Space (3D UMAP)")
+    plt.savefig(os.path.join(output_dir, f"{prefix}_umap_3d.png"))
+    plt.close()
+
+    return base_pca2, overlay_pca2


### PR DESCRIPTION
## Summary
- extend `plot_latent_overlay` to take patch sources for base and overlay features
- color PCA/t-SNE/UMAP overlays by patch source
- pass patch sources in `latent_plot.py` and `main.py`

## Testing
- `python -m py_compile latent_plot.py main.py visualization.py`

------
https://chatgpt.com/codex/tasks/task_e_684f6f7c14dc83218908095a75e4d1ce