### PR TITLE
Fix latent overlay base feature alignment

### DIFF
--- a/main.py
+++ b/main.py
@@ -223,8 +223,11 @@ def main():
 
 
 
+        # Visualize the feature distribution with the known site embeddings
+        # overlaid. Use the features from all rasters as the base data so that
+        # ``base_sources`` matches the length of ``base_features``.
         plot_latent_overlay(
-            features,
+            all_features,
             site_features_det,
             base_sources=all_sources,
             overlay_sources=["known_site"] * len(site_features_det),


### PR DESCRIPTION
## Summary
- fix out-of-bounds indexing in `plot_latent_overlay`

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852debf83888321ba2345016d0f8ab8