### PR TITLE
Add interval-based latent space plotting

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,6 +36,10 @@ def setup_args():
                         help='Number of patches to sample for training')
     parser.add_argument('--epochs', type=int, default=20,
                         help='Number of training epochs')
+    parser.add_argument('--latent_interval', type=int, default=100,
+                        help='Epoch interval for UMAP/t-SNE/PCA plots')
+    parser.add_argument('--latent_sample_size', type=int, default=1000,
+                        help='Number of patches to sample for latent plots')
     parser.add_argument('--detection_method', type=str, choices=['iforest', 'kmeans'], default='iforest',
                         help='Method for anomaly detection')
     parser.add_argument('--test_tile', type=str, default=None,
@@ -124,7 +128,9 @@ def main():
             X1, X2, labels,
             epochs=args.epochs,
             save_dir=model_dir,
-            checkpoint_dir=os.path.join(args.output_dir, "checkpoints")
+            checkpoint_dir=os.path.join(args.output_dir, "checkpoints"),
+            latent_interval=args.latent_interval,
+            latent_sample_size=args.latent_sample_size,
         )
 
         plot_training_loss(history, os.path.join(results_dir, "training_loss.png"))

--- a/main.py
+++ b/main.py
@@ -40,6 +40,10 @@ def setup_args():
                         help='Epoch interval for UMAP/t-SNE/PCA plots')
     parser.add_argument('--latent_sample_size', type=int, default=1000,
                         help='Number of patches to sample for latent plots')
+    parser.add_argument('--latent_quick_interval', type=int, default=10,
+                        help='Epoch interval for lightweight latent plots')
+    parser.add_argument('--latent_quick_size', type=int, default=200,
+                        help='Number of patches for quick latent plots')
     parser.add_argument('--detection_method', type=str, choices=['iforest', 'kmeans'], default='iforest',
                         help='Method for anomaly detection')
     parser.add_argument('--test_tile', type=str, default=None,
@@ -131,6 +135,8 @@ def main():
             checkpoint_dir=os.path.join(args.output_dir, "checkpoints"),
             latent_interval=args.latent_interval,
             latent_sample_size=args.latent_sample_size,
+            latent_quick_interval=args.latent_quick_interval,
+            latent_quick_size=args.latent_quick_size,
         )
 
         plot_training_loss(history, os.path.join(results_dir, "training_loss.png"))

--- a/model.py
+++ b/model.py
@@ -7,7 +7,11 @@ from typing import Optional
 import matplotlib.pyplot as plt
 
 from checkpoint import CheckpointManager
-from visualization import plot_training_loss
+from visualization import (
+    plot_training_loss,
+    compute_embeddings,
+    plot_latent_overlay,
+)
 
 
 class Encoder(nn.Module):
@@ -79,8 +83,25 @@ def train_siamese_model(
     checkpoint_dir: str | None = None,
     checkpoint_interval: int = 1,
     plot_interval: int = 1,
+    latent_interval: int | None = None,
+    latent_sample_size: int = 1000,
 ):
-    """Train Siamese network using PyTorch."""
+    """Train Siamese network using PyTorch.
+
+    Args:
+        X1, X2: Patch pairs for contrastive training.
+        labels: Pair labels (1=same, 0=different).
+        embedding_dim: Dimension of the encoder output.
+        epochs: Number of training epochs.
+        batch_size: Batch size for DataLoader.
+        margin: Contrastive loss margin.
+        save_dir: Directory to save models and plots.
+        checkpoint_dir: Directory for checkpoint files.
+        checkpoint_interval: Save checkpoint every N epochs.
+        plot_interval: Save loss plot every N epochs.
+        latent_interval: If set, generate latent UMAP/t-SNE/PCA plots every N epochs.
+        latent_sample_size: Number of patches to sample for latent plots.
+    """
     X1_t = _prepare_tensor(X1)
     X2_t = _prepare_tensor(X2)
     y_t = torch.from_numpy(labels).float()
@@ -120,6 +141,16 @@ def train_siamese_model(
                 ckpt.save(epoch, model, optimizer, history)
             if (epoch + 1) % plot_interval == 0:
                 plot_training_loss(history, os.path.join(save_dir, "training_history.png"))
+            if latent_interval and (epoch + 1) % latent_interval == 0:
+                sample_idx = np.random.choice(len(X1), min(latent_sample_size, len(X1)), replace=False)
+                sample_patches = X1[sample_idx]
+                emb = compute_embeddings(encoder, sample_patches)
+                plot_latent_overlay(
+                    emb,
+                    None,
+                    output_dir=save_dir,
+                    prefix=f"latent_epoch_{epoch+1}",
+                )
     except KeyboardInterrupt:
         print("Training interrupted. Saving checkpoint...")
         ckpt.save(epoch, model, optimizer, history)
@@ -130,6 +161,11 @@ def train_siamese_model(
     torch.save(model.state_dict(), os.path.join(save_dir, "siamese.pt"))
     ckpt.save(epochs - 1, model, optimizer, history)
     plot_training_loss(history, os.path.join(save_dir, "training_history.png"))
+    if latent_interval:
+        sample_idx = np.random.choice(len(X1), min(latent_sample_size, len(X1)), replace=False)
+        sample_patches = X1[sample_idx]
+        emb = compute_embeddings(encoder, sample_patches)
+        plot_latent_overlay(emb, None, output_dir=save_dir, prefix="latent_final")
 
     return encoder, model, history
 
@@ -162,4 +198,4 @@ if __name__ == "__main__":
     X1 = np.random.rand(10, 64, 64)
     X2 = np.random.rand(10, 64, 64)
     y = np.random.randint(0, 2, size=10)
-    train_siamese_model(X1, X2, y, epochs=1)
+    train_siamese_model(X1, X2, y, epochs=1, latent_interval=None)


### PR DESCRIPTION
## Summary
- allow optional epoch interval for UMAP/t‑SNE/PCA visualisation
- expose new arguments `--latent_interval` and `--latent_sample_size`
- generate quick latent plots during training and at the end

## Testing
- `python -m py_compile *.py`
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685883bd0c3c832183c82e60e26f2068